### PR TITLE
Populate advisory database

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-advisory.md
+++ b/.github/ISSUE_TEMPLATE/new-advisory.md
@@ -3,19 +3,15 @@ name: New advisory
 about: Create a new advisory in this database
 title: "[New advisory]"
 labels: advisory
-assignees: ''
-
+assignees: ""
 ---
 
-Provide following details to initiate a pull request creating a new advisory in this database.
+Provide following details to initiate a pull request creating a new advisory in
+this database.
 
 <!-- atomist-advisory:start -->
 
-id: vonwig/V-2022-{{increment}}
-cve ids:  
-cwe ids:
-severity:
-summary:
-details:
+id: vonwig/V-2022-{{increment}} cve ids:  
+cwe ids: severity: summary: details:
 
 <!-- atomist-advisory:end -->

--- a/ADVISORY_TEMPLATE.json
+++ b/ADVISORY_TEMPLATE.json
@@ -3,48 +3,44 @@
   "id": "V-2022-0001",
   "modified": "2022-01-01T00:00:00Z",
   "published": "2022-01-01T00:00:00Z",
-  "aliases": [
-	"CVE-2022-xxxx"
-  ],
+  "aliases": ["CVE-2022-xxxx"],
   "summary": "",
   "details": "",
   "severity": [
-	{
-	  "type": "CVSS_V3",
-	  "score": ""
-	}
+    {
+      "type": "CVSS_V3",
+      "score": ""
+    }
   ],
   "affected": [
-	{
-	  "package": {
-		"ecosystem": "NPM",
-		"purl": "pkg:npm/hello-world"
-	  },
-	  "ranges": [
-		{
-		  "type": "ECOSYSTEM",
-		  "events": [
-			{
-			  "introduced": "0"
-			},
-			{
-			  "fixed": "1.0.0"
-			}
-		  ]
-		}
-	  ]
-	}
+    {
+      "package": {
+        "ecosystem": "NPM",
+        "purl": "pkg:npm/hello-world"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.0.0"
+            }
+          ]
+        }
+      ]
+    }
   ],
   "references": [
-	{
-	  "type": "ADVISORY",
-	  "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-xxxx"
-	}
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-xxxx"
+    }
   ],
   "database_specific": {
-	"cwe_ids": [
-	  "CWE-xxx"
-	],
-	"severity": "CRITICAL|HIGH|MEDIUM|LOW",
+    "cwe_ids": ["CWE-xxx"],
+    "severity": "CRITICAL|HIGH|MEDIUM|LOW"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
 # Atomist Vulnerability and Advisory DB
 
-This repository contains private advisories to be managed as part of the Atomist Vulnerability Database. Information 
-in this repository will not be part of the global Atomist Vulnerability Database.
-   
+This repository contains private advisories to be managed as part of the Atomist
+Vulnerability Database. Information in this repository will not be part of the
+global Atomist Vulnerability Database.
+
 Advisories are managed in JSON files placed in directories of this repository.
 
 ## Managing Advisories
 
 ### Adding Advisories
 
-Creating new advisories can be achieved by either creating a new JSON advisory file in the `main` branch by manually
-or by opening a new GitHub issue using the _New advisory_ issue template. Once the issue is raised, a pull request with
-a new skeleton advisory JSON file is opened. 
+Creating new advisories can be achieved by either creating a new JSON advisory
+file in the `main` branch by manually or by opening a new GitHub issue
+using the [_New advisory_](ADVISORY_TEMPLATE.json) issue template. Once the issue is raised, 
+a pull request with a new skeleton advisory JSON file is opened.
 
-The content of advisory JSON files strictly follows the schema defined in [Open Source Vulnerability (OSV) format](https://ossf.github.io/osv-schema/). 
-Take a look at the [GitHub Advisory Database](https://github.com/github/advisory-database/tree/main/advisories/github-reviewed) for examples of advisories.
-           
+The content of advisory JSON files strictly follows the schema defined in
+[Open Source Vulnerability (OSV) format](https://ossf.github.io/osv-schema/).
+Take a look at the
+[GitHub Advisory Database](https://github.com/github/advisory-database/tree/main/advisories/github-reviewed)
+for examples of advisories.
+
 ### Updating Advisories
 
-To update an advisory, change the corresponding JSON advisory file either directly in the `main` branch of this repository
-or raise a pull request with your updates. 
+To update an advisory, change the corresponding JSON advisory file either
+directly in the `main` branch of this repository or raise a pull request
+with your updates.
 
-Once the changes are committed to the `main` branch, the advisory will get updated in the database automatically.
-A GitHub Check will indicate the successful update of the advisory. 
+Once the changes are committed to the `main` branch, the advisory will get
+updated in the database automatically. A GitHub Check will indicate the
+successful update of the advisory.
 
 ### Deleting Advisories
 
-Deleting an advisory from the database can be achieved by removing the corresponding JSON advisory file from the `main` branch of this repository.
+Deleting an advisory from the database can be achieved by removing the
+corresponding JSON advisory file from the `main` branch of this
+repository.
 
-> 💡 Only additions, changes and removals of JSON advisory files in the repository's default branch are being processed and mirrored into the database.
-
-
-
+> 💡 Only additions, changes and removals of JSON advisory files in the
+> repository's default branch are being processed and mirrored into the
+> database.


### PR DESCRIPTION
This pull request adds documentation and templates to managed Atomist advisories

---

Files changed:

-   [`.github/ISSUE_TEMPLATE/new-advisory.md`](https://github.com/vonwig/atomist-advisories/blob/atomist/populate-advisory/.github/ISSUE_TEMPLATE/new-advisory.md)
-   [`ADVISORY_TEMPLATE.json`](https://github.com/vonwig/atomist-advisories/blob/atomist/populate-advisory/ADVISORY_TEMPLATE.json)
-   [`README.md`](https://github.com/vonwig/atomist-advisories/blob/atomist/populate-advisory/README.md)

<!-- atomist:hide -->

<!-- atomist:show -->


<!--
  [atomist:generated]
  [atomist-skill:atomist/docker-vulnerability-scanner-skill]
  [atomist-version:0.1.159-1]
  [atomist-configuration:policy-cfg]
  [atomist-workspace-id:T095SFFBK]
  [atomist-correlation-id:bd75f33e-e6db-4e5d-a858-91ab58f52e1c.JvawqNaw8uboYaZpKcNOf]
  [atomist-diff:17067d828a478d02223854a75b278eb00ccd5bc69a8b549f6b7222e5992393e6]
-->